### PR TITLE
Major optimisations: 2x faster!

### DIFF
--- a/lib/Data/OptList.pm
+++ b/lib/Data/OptList.pm
@@ -149,12 +149,13 @@ sub mkopt {
   my ($moniker, $require_unique, $must_be); # the old positional args
   my $name_test;
 
-  if (@_ == 1 and Params::Util::_HASHLIKE($_[0])) {
-    my $arg = $_[0];
-    ($moniker, $require_unique, $must_be, $name_test)
-      = @$arg{ qw(moniker require_unique must_be name_test) };
-  } else {
-    ($moniker, $require_unique, $must_be) = @_;
+  if (@_) {
+    if (@_ == 1 and Params::Util::_HASHLIKE($_[0])) {
+      ($moniker, $require_unique, $must_be, $name_test)
+        = @{$_[0]}{ qw(moniker require_unique must_be name_test) };
+    } else {
+      ($moniker, $require_unique, $must_be) = @_;
+    }
   }
 
   $moniker = 'unnamed' unless defined $moniker;

--- a/lib/Data/OptList.pm
+++ b/lib/Data/OptList.pm
@@ -173,21 +173,22 @@ sub mkopt {
 
   for (my $i = 0; $i < @$opt_list; $i++) { ## no critic
     my $name = $opt_list->[$i];
-    my $value;
 
     if ($require_unique) {
       Carp::croak "multiple definitions provided for $name" if $seen{$name}++;
     }
 
-    if    ($i == $#$opt_list)               { $value = undef;            }
-    elsif (not defined $opt_list->[$i+1])   { $value = undef; $i++       }
-    elsif ($name_test->($opt_list->[$i+1])) { $value = undef;            }
-    else                                    { $value = $opt_list->[++$i] }
+    my $value;
 
-    if ($must_be and defined $value) {
-      unless (__is_a($value, $must_be)) {
-        my $ref = ref $value;
-        Carp::croak "$ref-ref values are not valid in $moniker opt list";
+    if ($i < $#$opt_list) {
+      if (not defined $opt_list->[$i+1]) {
+        $i++
+      } elsif (! $name_test->($opt_list->[$i+1])) {
+        $value = $opt_list->[++$i];
+        if ($must_be && !__is_a($value, $must_be)) {
+          my $ref = ref $value;
+          Carp::croak "$ref-ref values are not valid in $moniker opt list";
+        }
       }
     }
 

--- a/t/mkopt.t
+++ b/t/mkopt.t
@@ -84,6 +84,18 @@ is_deeply(
   "opt list of names and values expands with [must_be]",
 );
 
+is_deeply(
+  OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, [qw< HASH CODE >]),
+  [ [ foo => { a => 1 } ], [ ':bar' => undef ], [ baz => undef ] ],
+  "opt list of names and values expands with [must_be]",
+);
+
+is_deeply(
+  OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, [qw< CODE HASH >]),
+  [ [ foo => { a => 1 } ], [ ':bar' => undef ], [ baz => undef ] ],
+  "opt list of names and values expands with [must_be]",
+);
+
 {
   bless((my $object = {}), 'Test::DOL::Obj');
   is_deeply(
@@ -97,12 +109,27 @@ is_deeply(
     [ [ foo => $object ], [ ':bar' => undef ], [ baz => undef ] ],
     "opt list of names and values expands with [must_be], must_be object",
   );
+
+  is_deeply(
+    OPT([ foo => $object, ':bar', 'baz' ], 0, ['ARRAY', 'HASH', 'CODE', 'SCALAR', 'Test::DOL::Obj']),
+    [ [ foo => $object ], [ ':bar' => undef ], [ baz => undef ] ],
+    "opt list of names and values expands with [must_be], must_be object",
+  );
+
+  is_deeply(
+    OPT([ foo => $object, ':bar', 'baz' ], 0, ['Test::DOL::Obj', 'CODE']),
+    [ [ foo => $object ], [ ':bar' => undef ], [ baz => undef ] ],
+    "opt list of names and values expands with [must_be], must_be object",
+  );
 }
 
 eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, 'ARRAY'); };
 like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, ['ARRAY']); };
+like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
+
+eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, ['ARRAY', 'CODE', 'SCALAR', 'Foo']); };
 like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 eval {
@@ -120,6 +147,9 @@ eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, 'Test::DOL::Obj'); };
 like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, ['Test::DOL::Obj']); };
+like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
+
+eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, ['CODE', 'Test::DOL::Obj']); };
 like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 is_deeply(

--- a/t/mkopt.t
+++ b/t/mkopt.t
@@ -100,10 +100,10 @@ is_deeply(
 }
 
 eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, 'ARRAY'); };
-like($@, qr/HASH-ref values are not/, "exception tossed on invaild ref value");
+like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, ['ARRAY']); };
-like($@, qr/HASH-ref values are not/, "exception tossed on invaild ref value");
+like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 eval {
   mkopt(
@@ -114,13 +114,13 @@ eval {
     }
   );
 };
-like($@, qr/HASH-ref values are not/, "exception tossed on invaild ref value");
+like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, 'Test::DOL::Obj'); };
-like($@, qr/HASH-ref values are not/, "exception tossed on invaild ref value");
+like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 eval { OPT([ foo => { a => 1 }, ':bar', 'baz' ], 0, ['Test::DOL::Obj']); };
-like($@, qr/HASH-ref values are not/, "exception tossed on invaild ref value");
+like($@, qr/HASH-ref values are not/, "exception tossed on invalid ref value");
 
 is_deeply(
   OPT([ foo => { a => 1 }, ':bar' => undef, 'baz' ]),


### PR DESCRIPTION
While profiling Dist::Zilla with Devel::NYTProf I noticed that Data::OptList is heavily used. For example when building the Data-OptList distribution, `mkopt` is called 2704 times (from Moose and Sub::Exporter) and `mkopt_hash` 237 times (called by Sub::Exporter).

So here is a set of MAJOR optimisations:
- the heart of the mkopt main loop is reworked to reduce redundant paths
- the `$must_be` parameter is compiled into a closure (this benefits to Sub::Exporter)
- more tests are added for improved code paths coverage

**This will give a boost to any Moose application!**

Some statistics (second line is with my optimisations):

| mkopt calls | mkopt inclusive time | mkopt_hash inclusive time | benchmark command (in the Data-OptList repo) |
| --- | --- | --- | --- |
| 2704 | 91.3ms | 32.8ms | `perl -d:NYTProf -S dzil test` |
| 2704 | 52.8ms | 31.3ms | `PERL5LIB="$PWD/lib" perl -d:NYTProf -ME='$Data::OptList::VERSION="0.110"' -S dzil test` |

Cc: @karenetheridge @dagolden @kentfredric @autarch @doy @sartak @shadowcat-mst
