### PR TITLE
use Params::SomeUtil in place of Params::Util

### DIFF
--- a/lib/Data/OptList.pm
+++ b/lib/Data/OptList.pm
@@ -4,7 +4,7 @@ package Data::OptList;
 # ABSTRACT: parse and validate simple name/value option pairs
 
 use List::Util ();
-use Params::Util ();
+use Params::SomeUtil ();
 use Sub::Install 0.921 ();
 
 =head1 SYNOPSIS
@@ -108,7 +108,7 @@ The C<must_be> parameter is either a scalar or array of scalars; it defines
 what kind(s) of refs may be values.  If an invalid value is found, an exception
 is thrown.  If no value is passed for this argument, any reference is valid.
 If C<must_be> specifies that values must be CODE, HASH, ARRAY, or SCALAR, then
-Params::Util is used to check whether the given value can provide that
+Params::SomeUtil is used to check whether the given value can provide that
 interface.  Otherwise, it checks that the given value is an object of the kind.
 
 In other words:
@@ -124,10 +124,10 @@ Means:
 my %test_for;
 BEGIN {
   %test_for = (
-    CODE   => \&Params::Util::_CODELIKE,  ## no critic
-    HASH   => \&Params::Util::_HASHLIKE,  ## no critic
-    ARRAY  => \&Params::Util::_ARRAYLIKE, ## no critic
-    SCALAR => \&Params::Util::_SCALAR0,   ## no critic
+    CODE   => \&Params::SomeUtil::_CODELIKE,  ## no critic
+    HASH   => \&Params::SomeUtil::_HASHLIKE,  ## no critic
+    ARRAY  => \&Params::SomeUtil::_ARRAYLIKE, ## no critic
+    SCALAR => \&Params::SomeUtil::_SCALAR0,   ## no critic
   );
 }
 
@@ -138,7 +138,7 @@ sub mkopt {
   my ($name_test, $is_a);
 
   if (@_) {
-    if (@_ == 1 and Params::Util::_HASHLIKE($_[0])) {
+    if (@_ == 1 and Params::SomeUtil::_HASHLIKE($_[0])) {
       ($moniker, $require_unique, $must_be, $name_test)
         = @{$_[0]}{ qw(moniker require_unique must_be name_test) };
     } else {
@@ -153,7 +153,7 @@ sub mkopt {
       my @checks = map {
           my $class = $_;
           $test_for{$class}
-          || sub { Params::Util::_INSTANCE($_[0], $class) }
+          || sub { Params::SomeUtil::_INSTANCE($_[0], $class) }
       } @$must_be;
 
       $is_a = (@checks == 1)

--- a/t/mkopt.t
+++ b/t/mkopt.t
@@ -10,6 +10,7 @@ These tests test option list cannonization (from an option list into a aref).
 
 use Data::OptList;
 use Sub::Install;
+use Params::SomeUtil ();
 use Test::More 0.88;
 
 
@@ -183,7 +184,7 @@ is_deeply(
     [ @input ],
     {
       moniker   => 'test',
-      name_test => sub { ! ref $_[0] or Params::Util::_ARRAYLIKE($_[0]) },
+      name_test => sub { ! ref $_[0] or Params::SomeUtil::_ARRAYLIKE($_[0]) },
     },
   ),
   [


### PR DESCRIPTION
This substitutes `Params::SomeUtil` for `Params::Util`.  https://metacpan.org/pod/Params::SomeUtil#WHY describes the differences between these two modules, and why I forked.  TL;DR `Params::Util` does not install without a compiler, even though it includes a pure-perl implementation.

I'm open to other fixes if you have feedback, or making changes to `Params::SomeUtil`, or adding comaint as mentioned in its documentation, I just want things to work, I don't use these modules directly, but they are dependency of `Getopt::Long::Descriptive` which I am trying to employ in a pure-perl fat packed script for work.

Thank you for your consideration.